### PR TITLE
fix: Accessibility improvements - ARIA tabs, color contrast, decorative emojis

### DIFF
--- a/src/components/DatePicker.jsx
+++ b/src/components/DatePicker.jsx
@@ -185,7 +185,7 @@ export default function DatePicker({ onSubmit }) {
               className={`w-full px-5 py-4 text-lg font-sans text-center rounded-xl border-2 transition-all duration-200 focus:outline-none bg-white border-charcoal-200 text-charcoal-800 placeholder-charcoal-400 focus:border-amber focus:ring-2 focus:ring-amber/20 ${isLoading ? 'opacity-50 cursor-not-allowed' : ''}`}
               autoComplete="off"
             />
-            <p className="text-xs font-sans text-center mt-2 text-charcoal-400">
+            <p className="text-xs font-sans text-center mt-2 text-charcoal-500">
               Supporting birth years from {MIN_YEAR} to {MAX_YEAR}
             </p>
           </div>
@@ -232,7 +232,7 @@ export default function DatePicker({ onSubmit }) {
         </div>
 
         {/* Privacy note */}
-        <p className="text-xs font-sans text-center mt-6 md:mt-8 text-charcoal-400 px-2">
+        <p className="text-xs font-sans text-center mt-6 md:mt-8 text-charcoal-500 px-2">
           Your birth date is used only to generate your personalized report.
           <br className="hidden sm:block" />
           <span className="sm:hidden"> </span>

--- a/src/components/ThemeSwitcher.jsx
+++ b/src/components/ThemeSwitcher.jsx
@@ -102,7 +102,7 @@ export default function ThemeSwitcher() {
       {/* Desktop sidebar - hidden on mobile */}
       <div className="fixed left-0 top-1/2 -translate-y-1/2 z-50 hidden md:block">
         <div className="bg-dark-brown/95 backdrop-blur rounded-r-lg py-3 px-2 shadow-xl flex flex-col gap-1">
-          <p className="text-[10px] font-body text-vintage-cream/50 uppercase tracking-wider text-center mb-1 px-1">
+          <p className="text-[10px] font-body text-vintage-cream/80 uppercase tracking-wider text-center mb-1 px-1">
             Theme
           </p>
           {themes.map((theme) => (
@@ -117,7 +117,7 @@ export default function ThemeSwitcher() {
                 }`}
               title={theme.label}
             >
-              <span className="text-lg">{theme.icon}</span>
+              <span className="text-lg" aria-hidden="true">{theme.icon}</span>
               <span className="absolute left-full ml-2 top-1/2 -translate-y-1/2 bg-dark-brown text-vintage-cream
                              text-xs px-2 py-1 rounded whitespace-nowrap opacity-0 group-hover:opacity-100
                              transition-opacity pointer-events-none shadow-lg">
@@ -128,7 +128,7 @@ export default function ThemeSwitcher() {
 
           <div className="h-px bg-vintage-cream/20 my-2" />
 
-          <p className="text-[10px] font-body text-vintage-cream/50 uppercase tracking-wider text-center mb-1 px-1">
+          <p className="text-[10px] font-body text-vintage-cream/80 uppercase tracking-wider text-center mb-1 px-1">
             Size
           </p>
           <div className="flex flex-col gap-1">
@@ -167,7 +167,7 @@ export default function ThemeSwitcher() {
                    active:scale-95 transition-transform"
         aria-label="Open theme settings"
       >
-        <span className="text-vintage-cream">⚙️</span>
+        <span className="text-vintage-cream" aria-hidden="true">⚙️</span>
       </button>
 
       {/* Mobile bottom sheet overlay */}
@@ -194,7 +194,7 @@ export default function ThemeSwitcher() {
 
             {/* Theme selection */}
             <div className="mb-6">
-              <p className="text-xs font-body text-vintage-cream/50 uppercase tracking-wider mb-3">
+              <p className="text-xs font-body text-vintage-cream/80 uppercase tracking-wider mb-3">
                 Theme
               </p>
               <div className="flex gap-3">
@@ -208,7 +208,7 @@ export default function ThemeSwitcher() {
                         : 'bg-vintage-cream/10 text-vintage-cream/70 active:bg-vintage-cream/20'
                       }`}
                   >
-                    <span className="text-2xl">{theme.icon}</span>
+                    <span className="text-2xl" aria-hidden="true">{theme.icon}</span>
                     <span className="text-sm font-medium">{theme.label}</span>
                   </button>
                 ))}
@@ -217,7 +217,7 @@ export default function ThemeSwitcher() {
 
             {/* Font size selection */}
             <div>
-              <p className="text-xs font-body text-vintage-cream/50 uppercase tracking-wider mb-3">
+              <p className="text-xs font-body text-vintage-cream/80 uppercase tracking-wider mb-3">
                 Text Size
               </p>
               <div className="flex gap-3">


### PR DESCRIPTION
## Summary

This PR implements three accessibility improvements:

1. **#48 - ARIA Tab Pattern**: Adds proper WAI-ARIA tab pattern to all three themes (Timeline, Newspaper, CaseFile) with keyboard navigation support
2. **#49 - Color Contrast WCAG AA**: Fixes text color contrast issues to meet 4.5:1 ratio requirement
3. **#50 - Decorative Emojis**: Hides decorative emojis from screen readers with aria-hidden

## Changes

### ARIA Tab Pattern (#48)
- Added `role="tablist"` container with `role="tab"` buttons
- Added `role="tabpanel"` to content areas with proper labeling
- Implemented arrow key navigation (Left/Right/Home/End) per WAI-ARIA APG
- Proper focus management and tabIndex handling

### Color Contrast (#49)
- TimelineTheme: Removed opacity from text-sepia-brown labels
- CaseFileTheme: Removed text-sepia-brown/70 opacity on labels  
- NewspaperTheme: Darkened text-stone-500 to text-stone-600
- ThemeSwitcher: Increased text-vintage-cream/50 to /80
- DatePicker: Darkened text-charcoal-400 to charcoal-500

### Decorative Emojis (#50)
- Added `aria-hidden="true"` to all decorative emojis across themes
- Section icons, tab icons, separators, and settings gear

## Test Plan

- [x] Build passes
- [x] All 20 tests pass
- [x] ARIA implementation verified by accessibility expert review
- [ ] Manual VoiceOver testing
- [ ] Lighthouse accessibility audit

Fixes #48, Fixes #49, Fixes #50

Made with [Cursor](https://cursor.com)